### PR TITLE
revise contract to suit frontend tutorial

### DIFF
--- a/src/Insurance.sol
+++ b/src/Insurance.sol
@@ -4,27 +4,37 @@ pragma solidity ^0.8.0;
 import "@uma/core/contracts/optimistic-oracle-v3/implementation/ClaimData.sol";
 import "@uma/core/contracts/optimistic-oracle-v3/interfaces/OptimisticOracleV3Interface.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
-// This Isurance contract enables for the issuance of a single unlimited time policy per event/payout recipient There is
-// no limit to the number of payout requests that can be made of the same policy; however, only the first asserted
-// request will settle the insurance payment, whereas OOv3 will settle bonds for all requestors.
-contract Insurance {
+contract InsuranceTutorial is Ownable{
     using SafeERC20 for IERC20;
     IERC20 public immutable defaultCurrency;
     OptimisticOracleV3Interface public immutable oo;
     uint64 public constant assertionLiveness = 7200;
     bytes32 public immutable defaultIdentifier;
 
+    enum Status {
+        UNINIITIALIZED,
+        OPEN,
+        REQUESTED,
+        SETTLED
+    }
+
     struct Policy {
         uint256 insuranceAmount;
         address payoutAddress;
         bytes insuredEvent;
-        bool settled;
+        Status status;
+        bytes32 assertionId;
     }
 
     mapping(bytes32 => bytes32) public assertedPolicies;
 
     mapping(bytes32 => Policy) public policies;
+    // insuredEvent => BPS price per policy amount
+    mapping(bytes32 => uint256) public insuredEventPrice;
+
+    uint256 public totalLiabilities;
 
     event InsuranceIssued(
         bytes32 indexed policyId,
@@ -37,38 +47,45 @@ contract Insurance {
 
     event InsurancePayoutSettled(bytes32 indexed policyId, bytes32 indexed assertionId);
 
+    event InsuredEventSet(bytes32 indexed insuredEvent, uint256 price);
+
     constructor(address _defaultCurrency, address _optimisticOracleV3) {
         defaultCurrency = IERC20(_defaultCurrency);
         oo = OptimisticOracleV3Interface(_optimisticOracleV3);
         defaultIdentifier = oo.defaultIdentifier();
     }
 
-    function issueInsurance(
+    function createPolicy(
         uint256 insuranceAmount,
         address payoutAddress,
         bytes memory insuredEvent
     ) public returns (bytes32 policyId) {
+        require(insuredEventPrice[insuredEvent] > 0, "insuredEvent invalid");
+        require(insuranceAmount <= defaultCurrency.balanceOf(address(this)) - totalLiabilities, "insuranceAmount not available");
         policyId = keccak256(abi.encode(insuredEvent, payoutAddress));
         require(policies[policyId].payoutAddress == address(0), "Policy already exists");
         policies[policyId] = Policy({
             insuranceAmount: insuranceAmount,
             payoutAddress: payoutAddress,
             insuredEvent: insuredEvent,
-            settled: false
+            status: Status.OPEN,
+            assertionId : ''
         });
-        defaultCurrency.safeTransferFrom(msg.sender, address(this), insuranceAmount);
+        defaultCurrency.safeTransferFrom(msg.sender, address(this), insuranceAmount * insuredEventPrice[insuredEvent] / 10000 );
         emit InsuranceIssued(policyId, insuredEvent, insuranceAmount, payoutAddress);
     }
 
     function requestPayout(bytes32 policyId) public returns (bytes32 assertionId) {
-        require(policies[policyId].payoutAddress != address(0), "Policy does not exist");
+        Policy storage policy = policies[policyId];
+        require(policy.payoutAddress != address(0), "Policy does not exist");
+        require(policy.status == Status.OPEN, "Policy is not currently OPEN");
         uint256 bond = oo.getMinimumBond(address(defaultCurrency));
         defaultCurrency.safeTransferFrom(msg.sender, address(this), bond);
         defaultCurrency.safeApprove(address(oo), bond);
         assertionId = oo.assertTruth(
             abi.encodePacked(
                 "Insurance contract is claiming that insurance event ",
-                policies[policyId].insuredEvent,
+                policy.insuredEvent,
                 " had occurred as of ",
                 ClaimData.toUtf8BytesUint(block.timestamp),
                 "."
@@ -83,14 +100,34 @@ contract Insurance {
             bytes32(0) // No domain.
         );
         assertedPolicies[assertionId] = policyId;
+
+        policy.status = Status.REQUESTED;
+        policy.assertionId = assertionId;
         emit InsurancePayoutRequested(policyId, assertionId);
+    }
+    // note: price in BPS, insuredEvents with price = 0 are invalid
+    function setInsuredEvent(bytes32 insuredEvent, uint256 price) external onlyOwner {
+        insuredEventPrice[insuredEvent] = price;
+        emit InsuredEventSet(insuredEvent, price);
+    }
+
+    function withdrawFunds(address receiver, uint256 withdrawAmount) external onlyOwner {
+        require(withdrawAmount <= defaultCurrency.balanceOf(address(this)) - totalLiabilities, "withdrawAmount not available");
+        defaultCurrency.safeTransfer(receiver, withdrawAmount);
     }
 
     function assertionResolvedCallback(bytes32 assertionId, bool assertedTruthfully) public {
         require(msg.sender == address(oo));
-        // If the assertion was true, then the policy is settled.
+        
         if (assertedTruthfully) {
+            // If the assertion was true, then the policy is settled.
             _settlePayout(assertionId);
+        } else {
+            // If the assertion was false, then the policy is set back to OPEN.
+            bytes32 policyId = assertedPolicies[assertionId];
+            Policy storage policy = policies[policyId];
+            policy.status = Status.OPEN;
+            policy.assertionId = '';
         }
     }
 
@@ -101,8 +138,8 @@ contract Insurance {
         // OptimisticOracleV3, which may block the assertion resolution.
         bytes32 policyId = assertedPolicies[assertionId];
         Policy storage policy = policies[policyId];
-        if (policy.settled) return;
-        policy.settled = true;
+        if (policy.status == Status.SETTLED) return;
+        policy.status = Status.SETTLED;
         defaultCurrency.safeTransfer(policy.payoutAddress, policy.insuranceAmount);
         emit InsurancePayoutSettled(policyId, assertionId);
     }


### PR DESCRIPTION
Insurance.sol was revised to better suit a frontend tutorial. Please consider updating the master version for consistency with the frontend tutorial.

Test files have not yet been updated for the Insurance.sol revisions

summary of changes:
1.  replaced issuePolicy with createPolicy, so that policies can be permissionlessly bought by a beneficiary rather than an insurer creating the policy. This allows for a user interactive frontend. This change required making the contract ownable, so an owner can set pricing for insurable events and withdraw funds deposited into the contract to cover policy liabilities
2. added a Status Enum and assertionId to the Policy struct. This simplified the frontend so that all relevant policy data can be obtained from the policies mapping rather than querying the InsurancePayoutRequested and InsurancePayoutSettled events and writing logic to sort through the events. The changes make requesting and settling payouts less gas efficient.