### PR TITLE
Update Insurance.sol

### DIFF
--- a/src/Insurance.sol
+++ b/src/Insurance.sol
@@ -61,6 +61,9 @@ contract Insurance {
     }
 
     function requestPayout(bytes32 policyId) public returns (bytes32 assertionId) {
+        require(defaultCurrency.balanceOf(msg.sender) >= bond, "Insufficient balance for bond");
+        require(defaultCurrency.allowance(msg.sender, address(this)) >= bond, "Insufficient allowance for bond");
+
         require(policies[policyId].payoutAddress != address(0), "Policy does not exist");
         uint256 bond = oo.getMinimumBond(address(defaultCurrency));
         defaultCurrency.safeTransferFrom(msg.sender, address(this), bond);


### PR DESCRIPTION
The function assumes the user can transfer the bond amount. If the sender lacks sufficient funds or allowance for the bond, the transaction will fail without a clear error message. I have added a check for sender's balance and allowance before initiating the transfer: